### PR TITLE
Update channel calls/Make YT api calls more efficiently 

### DIFF
--- a/internal/database/actions.go
+++ b/internal/database/actions.go
@@ -123,6 +123,18 @@ func EpisodeExists(youtubeVideoId string, episodeType string) (bool, error) {
 	return true, nil
 }
 
+func PodcastExists(podcastId string) (bool, error) {
+	var episode models.Podcast
+	err := db.Where("id = ?", podcastId).First(&episode).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func GetLatestEpisode(podcastId string) (*models.PodcastEpisode, error) {
 	var episode models.PodcastEpisode
 	err := db.Where("podcast_id = ?", podcastId).Order("published_date DESC").First(&episode).Error
@@ -132,11 +144,6 @@ func GetLatestEpisode(podcastId string) (*models.PodcastEpisode, error) {
 	return &episode, nil
 }
 
-func GetAllPlaylistVideosByPlaylistId(playlistId string) []models.PodcastEpisode {
-	var episodes []models.PodcastEpisode
-	db.Where("playlist_id != ?", playlistId).Find(&episodes)
-	return episodes
-}
 func GetPodcastEpisodesByPodcastId(podcastId string) ([]models.PodcastEpisode, error) {
 	var episodes []models.PodcastEpisode
 	err := db.Where("podcast_id = ?", podcastId).Find(&episodes).Error

--- a/internal/models/podcast.go
+++ b/internal/models/podcast.go
@@ -1,17 +1,20 @@
 package models
 
 import (
+	"time"
+
 	"google.golang.org/api/youtube/v3"
 )
 
 type PodcastEpisode struct {
-	Id                 int32  `gorm:"autoIncrement;primary_key;not null"`
-	YoutubeVideoId     string `json:"youtube_video_id" gorm:"index:youtubevideoid_type"`
-	EpisodeName        string `json:"episode_name"`
-	EpisodeDescription string `json:"episode_description"`
-	PublishedDate      string `json:"published_date"`
-	Type               string `json:"type" gorm:"index:youtubevideoid_type_channelid_type"`
-	PodcastId          string `json:"podcast_id" gorm:"foreignkey:PodcastId;association_foreignkey:Id"`
+	Id                 int32         `gorm:"autoIncrement;primary_key;not null"`
+	YoutubeVideoId     string        `json:"youtube_video_id" gorm:"index:youtubevideoid_type"`
+	EpisodeName        string        `json:"episode_name"`
+	EpisodeDescription string        `json:"episode_description"`
+	PublishedDate      string        `json:"published_date"`
+	Type               string        `json:"type" gorm:"index:youtubevideoid_type_channelid_type"`
+	PodcastId          string        `json:"podcast_id" gorm:"foreignkey:PodcastId;association_foreignkey:Id"`
+	Duration           time.Duration `json:"duration"`
 }
 
 type Podcast struct {
@@ -34,7 +37,7 @@ type EpisodePlaybackHistory struct {
 	TotalTimeSkipped float64 `json:"total_time_skipped"`
 }
 
-func NewPodcastEpisode(youtubeVideo *youtube.PlaylistItem) PodcastEpisode {
+func NewPodcastEpisodeFromPlaylist(youtubeVideo *youtube.PlaylistItem) PodcastEpisode {
 	return PodcastEpisode{
 		YoutubeVideoId:     youtubeVideo.Snippet.ResourceId.VideoId,
 		EpisodeName:        youtubeVideo.Snippet.Title,
@@ -45,13 +48,14 @@ func NewPodcastEpisode(youtubeVideo *youtube.PlaylistItem) PodcastEpisode {
 	}
 }
 
-func NewPodcastEpisodeFromSearch(youtubeVideo *youtube.SearchResult) PodcastEpisode {
+func NewPodcastEpisodeFromSearch(youtubeVideo *youtube.Video, duration time.Duration) PodcastEpisode {
 	return PodcastEpisode{
-		YoutubeVideoId:     youtubeVideo.Id.VideoId,
+		YoutubeVideoId:     youtubeVideo.Id,
 		EpisodeName:        youtubeVideo.Snippet.Title,
 		EpisodeDescription: youtubeVideo.Snippet.Description,
 		PublishedDate:      youtubeVideo.Snippet.PublishedAt,
 		Type:               "CHANNEL",
 		PodcastId:          youtubeVideo.Snippet.ChannelId,
+		Duration:           duration,
 	}
 }

--- a/internal/services/generator.go
+++ b/internal/services/generator.go
@@ -182,42 +182,6 @@ func (i *Item) AddSummary(summary string) {
 	}
 }
 
-// AddDuration adds the duration to the iTunes duration field.
-func (i *Item) AddDuration(durationInSeconds int64) {
-	if durationInSeconds <= 0 {
-		return
-	}
-	i.IDuration = parseDuration(durationInSeconds)
-}
-
-var parseDuration = func(duration int64) string {
-	h := duration / 3600
-	duration = duration % 3600
-
-	m := duration / 60
-	duration = duration % 60
-
-	s := duration
-
-	// HH:MM:SS
-	if h > 9 {
-		return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
-	}
-
-	// H:MM:SS
-	if h > 0 {
-		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
-	}
-
-	// MM:SS
-	if m > 9 {
-		return fmt.Sprintf("%02d:%02d", m, s)
-	}
-
-	// M:SS
-	return fmt.Sprintf("%d:%02d", m, s)
-}
-
 var parseDateRFC1123Z = func(t *time.Time) string {
 	if t != nil && !t.IsZero() {
 		return t.Format(time.RFC1123Z)

--- a/internal/services/rss.go
+++ b/internal/services/rss.go
@@ -15,7 +15,7 @@ import (
 )
 
 func GenerateRssFeed(podcast models.Podcast, host string, podcastType enum.PodcastType) []byte {
-	log.Info("[RSS FEED] Generating RSS Feed with Youtube and Apple metadata")
+	log.Info("[RSS FEED] Generating RSS Feed...")
 
 	podcastLink := "https://www.youtube.com/playlist?list=" + podcast.Id
 
@@ -32,7 +32,7 @@ func GenerateRssFeed(podcast models.Podcast, host string, podcastType enum.Podca
 
 	if podcast.PodcastEpisodes != nil {
 		for _, podcastEpisode := range podcast.PodcastEpisodes {
-			if podcastEpisode.EpisodeName == "Private video" || podcastEpisode.EpisodeDescription == "This video is private." {
+			if (podcastEpisode.Type == "CHANNEL" && podcastEpisode.Duration.Seconds() < 120) || podcastEpisode.EpisodeName == "Private video" || podcastEpisode.EpisodeDescription == "This video is private." {
 				continue
 			}
 			mediaUrl := host + "/media/" + podcastEpisode.YoutubeVideoId + ".m4a"


### PR DESCRIPTION
- Update channel calls to be more efficient
- Grab full description when using channel as podcast
- Up the cutoff for yt shorts to 120 seconds so they wont be included in the RSS (likely will be configurable in later update with UI)